### PR TITLE
Add Assign Label GitHub Actions Workflow

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,22 @@
+enhancement:
+  - head-branch: ['^feat(ure)?', '^enhancement']
+bug:
+  - head-branch: ['^bug', '^fix']
+chore:
+  - head-branch: ['^chore']
+refactor:
+  - head-branch: ['^refactor']
+documentation:
+  - head-branch: ['^doc(ument)?', '^documentation']
+docker:
+  - changed-files:
+      - any-glob-to-any-file: ['infra/docker/*', 'compose.yaml']
+npm:
+  - changed-files:
+      - any-glob-to-any-file: ['package.json', 'package-lock.json']
+composer:
+  - changed-files:
+      - any-glob-to-any-file: ['composer.json', 'composer.lock']
+migrate:
+  - changed-files:
+      - any-glob-to-any-file: ['src/database/migrations/*']

--- a/.github/workflows/assign-label.yaml
+++ b/.github/workflows/assign-label.yaml
@@ -1,0 +1,17 @@
+name: Assign Label
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  assign-label:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yaml


### PR DESCRIPTION
## **User description**
close #10


___

## **Type**
enhancement


___

## **Description**
- プルリクエストが開かれた際に自動でラベルを割り当てるGitHub Actionsワークフローを追加。
- ワークフローは`ubuntu-latest`上で実行され、プルリクエストの`opened`および`synchronize`イベントに反応する。
- ラベルの設定ファイルとして`.github/labeler-branch.yaml`と`.github/labeler-files.yaml`が使用される。


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>assign-label.yaml</strong><dd><code>GitHub Actionsを使用した自動ラベル割り当てワークフローの追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/assign-label.yaml
<li>GitHub Actionsワークフローを追加し、プルリクエストが開かれたときに自動的にラベルを割り当てる。<br> <li> プルリクエストのイベントタイプが「opened」または「synchronize」の場合にトリガーされる。<br> <li> ラベルの設定は<code>.github/labeler-branch.yaml</code>と<code>.github/labeler-files.yaml</code>によって行われる。<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/ucan-lab/laravel-template/pull/11/files#diff-de7d8c72fe443ba4f99b37b8ad2c1dca3422f18c0380cea81f83bcea5b7fd048">+21/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

