### PR TITLE
Add Check Require Label GitHub Actions Workflow

### DIFF
--- a/.github/workflows/assign-label.yaml
+++ b/.github/workflows/assign-label.yaml
@@ -1,7 +1,7 @@
 name: Assign Label
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, labeled, unlabeled, synchronize, reopened]
 jobs:
   assign-label:
     permissions:
@@ -13,5 +13,35 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/labeler@v5
+        if: ${{ contains(fromJson('["opened", "synchronize"]'), github.event.action) }}
         with:
           configuration-path: .github/labeler.yaml
+  check-require-label:
+    needs: assign-label
+    permissions:
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - id: labels
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          json=$(gh pr view "$PR_NUMBER" --json labels | jq -c '.labels|map(.name)')
+          echo "json=$json" >> "$GITHUB_OUTPUT"
+      - name: Echo Label
+        run: echo "${{ steps.labels.outputs.json }}"
+      - name: bug, chore, dependencies, documentation, enhancement, refactor, release の中からいずれかのラベルを指定してください。
+        if: >-
+          ! contains(fromJSON(steps.labels.outputs.json), 'bug') &&
+          ! contains(fromJSON(steps.labels.outputs.json), 'chore') &&
+          ! contains(fromJSON(steps.labels.outputs.json), 'dependencies') &&
+          ! contains(fromJSON(steps.labels.outputs.json), 'documentation') &&
+          ! contains(fromJSON(steps.labels.outputs.json), 'enhancement') &&
+          ! contains(fromJSON(steps.labels.outputs.json), 'refactor') &&
+          ! contains(fromJSON(steps.labels.outputs.json), 'release')
+        run: exit 1
+      - name: Successfully
+        run: exit 0


### PR DESCRIPTION
## **User description**
close #12


___

## **Type**
enhancement, configuration changes


___

## **Description**
- プルリクエストのトリガーイベントに `labeled`, `unlabeled`, `reopened` を追加して、より多様なイベントでワークフローが動作するように変更
- ラベル付与の条件を `opened` または `synchronize` のアクションに限定し、その他のアクションではラベル付与をスキップ
- 新しいジョブ `check-require-label` を追加し、プルリクエストに `bug`, `chore`, `dependencies`, `documentation`, `enhancement`, `refactor`, `release` のいずれかのラベルがない場合にエラーを出すように設定


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>assign-label.yaml</strong><dd><code>GitHub Actionsのワークフロー更新: ラベル管理と必須チェック追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/assign-label.yaml
<li>プルリクエストのトリガータイプに <code>labeled</code>, <code>unlabeled</code>, <code>reopened</code> を追加<br> <li> ラベル自動付与の条件を <code>opened</code> または <code>synchronize</code> の場合に限定<br> <li> 必須ラベルチェックの新しいジョブを追加し、特定のラベルが付与されていない場合に失敗するように設定<br>


</details>
    

  </td>
  <td><a href="https://github.com/ucan-lab/laravel-template/pull/13/files#diff-de7d8c72fe443ba4f99b37b8ad2c1dca3422f18c0380cea81f83bcea5b7fd048">+31/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

